### PR TITLE
fix(utils): avoid panic when published_text has no space separator

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -158,8 +158,8 @@ pub fn published(published_text: &str) -> Result<u64> {
     let (num, time_frame) = {
         let v: Vec<&str> = published_text.splitn(2, ' ').collect();
 
-        match v[0].parse::<u64>() {
-            Ok(num) => (num, v[1]),
+        match (v[0].parse::<u64>(), v.get(1)) {
+            (Ok(num), Some(rest)) => (num, *rest),
             _ => (
                 v[0].trim_end_matches(char::is_alphabetic).parse()?,
                 v[0].trim_start_matches(char::is_numeric),
@@ -272,5 +272,15 @@ mod tests {
 
         assert_eq!(published(TEXT).unwrap(), time);
         assert_eq!(published_text(time).unwrap(), "Shared ".to_owned() + TEXT);
+    }
+
+    #[test]
+    fn published_handles_malformed_input_without_panic() {
+        // Inputs lacking a space previously panicked with index-out-of-bounds
+        // when `splitn(2, ' ')` returned a single element and the numeric
+        // branch unconditionally indexed `v[1]`. They must now return Err.
+        assert!(published("").is_err());
+        assert!(published("5").is_err());
+        assert!(published("123").is_err());
     }
 }


### PR DESCRIPTION
Fixes #18.

`published()` in `src/utils.rs` calls `splitn(2, ' ')` then unconditionally indexes `v[1]`. When `published_text` has no space and `v[0]` is purely numeric (e.g. a stray `"5"` returned by a stale/removed YouTube channel), `v.len() == 1` so the index panics:

```
thread 'tokio-rt-worker' panicked at src/utils.rs:162:31:
index out of bounds: the len is 1 but the index is 1
```

Matched on `(v[0].parse::<u64>(), v.get(1))` so the numeric branch only fires when a second token exists; otherwise we fall through to the trim-based branch (which now returns `Err` for digit-only input via the existing `starts_with` checks).

Added a regression test covering empty, `"5"`, and `"123"` inputs. `cargo test` and `cargo clippy --tests -- -D warnings` are clean.